### PR TITLE
Add CORS support for additional local development environments

### DIFF
--- a/app/middleware.py
+++ b/app/middleware.py
@@ -7,6 +7,9 @@ origins = [
     "http://127.0.0.1:3000",
     "http://localhost:8080",
     "http://localhost:3000",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+    "*",
     ]
 
 def add_cors_middleware(app):


### PR DESCRIPTION
Enhance CORS middleware to allow requests from localhost:5173 and 127.0.0.1:5173, along with a wildcard origin for broader development access.