### PR TITLE
Remove wildcard origin from CORS middleware for improved security

### DIFF
--- a/app/middleware.py
+++ b/app/middleware.py
@@ -9,7 +9,6 @@ origins = [
     "http://localhost:3000",
     "http://localhost:5173",
     "http://127.0.0.1:5173",
-    "*",
     ]
 
 def add_cors_middleware(app):


### PR DESCRIPTION
Eliminate the wildcard origin in the CORS middleware to enhance security by restricting allowed origins.