### PR TITLE
Make attendance_status optional in StudentClassListResponse model

### DIFF
--- a/app/routes/new_classes.py
+++ b/app/routes/new_classes.py
@@ -659,7 +659,7 @@ class StudentClassListResponse(BaseModel):
     age: int
     gender: str
     is_active: bool
-    attendance_status: str
+    attendance_status: Optional[str] = None
     guardian: GuardianResponse
 
 


### PR DESCRIPTION
Change the `attendance_status` field in the `StudentClassListResponse` model to be optional.